### PR TITLE
update terraform provider

### DIFF
--- a/terragrunt/attacker/module/versions.tf
+++ b/terragrunt/attacker/module/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     openstack = {
-      source = "terraform-providers/openstack"
+      source = "terraform-provider-openstack/openstack"
     }
   }
   required_version = ">= 0.13"

--- a/terragrunt/bootstrap/module/versions.tf
+++ b/terragrunt/bootstrap/module/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     openstack = {
-      source = "terraform-providers/openstack"
+      source = "terraform-provider-openstack/openstack"
     }
   }
   required_version = ">= 0.13"

--- a/terragrunt/logging/module/versions.tf
+++ b/terragrunt/logging/module/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     openstack = {
-      source = "terraform-providers/openstack"
+      source = "terraform-provider-openstack/openstack"
     }
   }
   required_version = ">= 0.13"

--- a/terragrunt/repository/module/versions.tf
+++ b/terragrunt/repository/module/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     openstack = {
-      source = "terraform-providers/openstack"
+      source = "terraform-provider-openstack/openstack"
     }
   }
   required_version = ">= 0.13"

--- a/terragrunt/videoserver/module/versions.tf
+++ b/terragrunt/videoserver/module/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     openstack = {
-      source = "terraform-providers/openstack"
+      source = "terraform-provider-openstack/openstack"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
This PR solves issue #18  (registry not found error)

- updates  `terraform-providers/openstack` to `terraform-provider-openstack/openstack`