### PR TITLE
Update default variables for packer

### DIFF
--- a/packer/adminpc/default.json.example
+++ b/packer/adminpc/default.json.example
@@ -1,5 +1,5 @@
 {
-    "base_image" : "ubuntu-2204",
+    "base_image" : "Ubuntu 22.04",
     "image_name" : "atb-adminpc-image",
     "security_group": "default",
     "network": "653b15f3-c7e1-41bf-99d5-f8ad0f96f959",

--- a/packer/adminpc/variables.pkr.hcl
+++ b/packer/adminpc/variables.pkr.hcl
@@ -14,7 +14,7 @@ variable "base_image" {
 variable "flavor" {
     type = string
     description = "The openstack flavor to use for the build host"
-    default = "m1.small"
+    default = "d2-2"
 }
 
 variable "security_group" {

--- a/packer/attacker/default.json.example
+++ b/packer/attacker/default.json.example
@@ -1,5 +1,5 @@
 {
-    "base_image" : "ubuntu-2204",
+    "base_image" : "Ubuntu 22.04",
     "image_name" : "atb-attacker-image",
     "security_group": "default",
     "network": "653b15f3-c7e1-41bf-99d5-f8ad0f96f959",

--- a/packer/attacker/variables.pkr.hcl
+++ b/packer/attacker/variables.pkr.hcl
@@ -14,7 +14,7 @@ variable "base_image" {
 variable "flavor" {
     type = string
     description = "The openstack flavor to use for the build host"
-    default = "m1.small"
+    default = "d2-2"
 }
 
 variable "security_group" {

--- a/packer/corpdns/default.json.example
+++ b/packer/corpdns/default.json.example
@@ -1,5 +1,5 @@
 {
-    "base_image" : "ubuntu-2204",
+    "base_image" : "Ubuntu 22.04",
     "image_name" : "atb-corpdns-image",
     "security_group": "default",
     "network": "653b15f3-c7e1-41bf-99d5-f8ad0f96f959",

--- a/packer/corpdns/variables.pkr.hcl
+++ b/packer/corpdns/variables.pkr.hcl
@@ -14,7 +14,7 @@ variable "base_image" {
 variable "flavor" {
     type = string
     description = "The openstack flavor to use for the build host"
-    default = "m1.small"
+    default = "d2-2"
 }
 
 variable "security_group" {

--- a/packer/firewall/default.json.example
+++ b/packer/firewall/default.json.example
@@ -1,5 +1,5 @@
 {
-    "base_image" : "ubuntu-2204",
+    "base_image" : "Ubuntu 22.04",
     "image_name" : "atb-fw-inet-lan-dmz-image",
     "security_group": "default",
     "network": "653b15f3-c7e1-41bf-99d5-f8ad0f96f959",

--- a/packer/firewall/variables.pkr.hcl
+++ b/packer/firewall/variables.pkr.hcl
@@ -14,7 +14,7 @@ variable "base_image" {
 variable "flavor" {
     type = string
     description = "The openstack flavor to use for the build host"
-    default = "m1.small"
+    default = "d2-2"
 }
 
 variable "security_group" {

--- a/packer/kafka/default.json.example
+++ b/packer/kafka/default.json.example
@@ -1,5 +1,6 @@
 {
-    "base_image" : "ubuntu-2204",
+    "base_image" : "Ubuntu 22.04",
+    "image_name" : "atb-kafka-image",
     "security_group": "default",
     "network": "653b15f3-c7e1-41bf-99d5-f8ad0f96f959",
     "floating_ip_pool": "provider-aecid-208"

--- a/packer/kafka/variables.pkr.hcl
+++ b/packer/kafka/variables.pkr.hcl
@@ -14,7 +14,7 @@ variable "base_image" {
 variable "flavor" {
     type = string
     description = "The openstack flavor to use for the build host"
-    default = "m1.small"
+    default = "d2-2"
 }
 
 variable "security_group" {

--- a/packer/linuxshare/default.json.example
+++ b/packer/linuxshare/default.json.example
@@ -1,5 +1,6 @@
 {
-    "base_image" : "ubuntu-2204",
+    "base_image" : "Debian 12",
+    "image_name" : "atb-linuxshare-image",
     "security_group": "default",
     "network": "653b15f3-c7e1-41bf-99d5-f8ad0f96f959",
     "floating_ip_pool": "provider-aecid-208"

--- a/packer/linuxshare/variables.pkr.hcl
+++ b/packer/linuxshare/variables.pkr.hcl
@@ -14,7 +14,7 @@ variable "base_image" {
 variable "flavor" {
     type = string
     description = "The openstack flavor to use for the build host"
-    default = "m1.small"
+    default = "d2-2"
 }
 
 variable "security_group" {
@@ -47,5 +47,5 @@ variable "timestamp_image" {
 variable "build_user" {
   type    = string
   description = "User to use when building the image"
-  default = "debian"
+  default = "debian" # thats for packer to log in to execute ansible
 }

--- a/packer/linuxshare/variables.pkr.hcl
+++ b/packer/linuxshare/variables.pkr.hcl
@@ -47,5 +47,5 @@ variable "timestamp_image" {
 variable "build_user" {
   type    = string
   description = "User to use when building the image"
-  default = "debian" # thats for packer to log in to execute ansible
+  default = "debian"
 }

--- a/packer/opensearch/default.json.example
+++ b/packer/opensearch/default.json.example
@@ -1,5 +1,6 @@
 {
-    "base_image" : "ubuntu-2204",
+    "base_image" : "Ubuntu 22.04",
+    "image_name" : "atb-opensearch-image",
     "security_group": "default",
     "network": "653b15f3-c7e1-41bf-99d5-f8ad0f96f959",
     "floating_ip_pool": "provider-aecid-208"

--- a/packer/opensearch/playbook/requirements.yml
+++ b/packer/opensearch/playbook/requirements.yml
@@ -6,7 +6,7 @@ roles:
     version: v1.1
     name: auditd
   - src: https://github.com/ait-testbed/atb-ansible-opensearch.git
-    version: v1.0.2
+    version: v1.0.1
     name: opensearch
   - src: https://github.com/ait-testbed/atb-ansible-opensearch-dashboards.git
     version: v1.0.2

--- a/packer/opensearch/variables.pkr.hcl
+++ b/packer/opensearch/variables.pkr.hcl
@@ -14,7 +14,7 @@ variable "base_image" {
 variable "flavor" {
     type = string
     description = "The openstack flavor to use for the build host"
-    default = "m1.small"
+    default = "r2-15"
 }
 
 variable "security_group" {

--- a/packer/repository/default.json.example
+++ b/packer/repository/default.json.example
@@ -1,5 +1,6 @@
 {
-    "base_image" : "ubuntu-2204",
+    "base_image" : "Ubuntu 22.04",
+    "image_name" : "atb-repository-image",
     "security_group": "default",
     "network": "653b15f3-c7e1-41bf-99d5-f8ad0f96f959",
     "floating_ip_pool": "provider-aecid-208"

--- a/packer/repository/variables.pkr.hcl
+++ b/packer/repository/variables.pkr.hcl
@@ -14,7 +14,7 @@ variable "base_image" {
 variable "flavor" {
     type = string
     description = "The openstack flavor to use for the build host"
-    default = "m1.medium"
+    default = "d2-4"
 }
 
 variable "security_group" {

--- a/packer/videoserver/default.json.example
+++ b/packer/videoserver/default.json.example
@@ -1,5 +1,5 @@
 {
-    "base_image" : "debian-11-amd64-20210814-734",
+    "base_image" : "Debian 11",
     "image_name" : "atb-videoserver-image",
     "security_group": "default",
     "network": "653b15f3-c7e1-41bf-99d5-f8ad0f96f959",

--- a/packer/videoserver/variables.pkr.hcl
+++ b/packer/videoserver/variables.pkr.hcl
@@ -14,7 +14,7 @@ variable "base_image" {
 variable "flavor" {
     type = string
     description = "The openstack flavor to use for the build host"
-    default = "m1.small"
+    default = "d2-2"
 }
 
 variable "security_group" {

--- a/packer/webcam/default.json.example
+++ b/packer/webcam/default.json.example
@@ -1,5 +1,6 @@
 {
-    "base_image" : "ubuntu-2204",
+    "base_image" : "Ubuntu 22.04",
+    "image_name" : "atb-webcam-image",
     "security_group": "default",
     "network": "653b15f3-c7e1-41bf-99d5-f8ad0f96f959",
     "floating_ip_pool": "provider-aecid-208"

--- a/packer/webcam/variables.pkr.hcl
+++ b/packer/webcam/variables.pkr.hcl
@@ -14,7 +14,7 @@ variable "base_image" {
 variable "flavor" {
     type = string
     description = "The openstack flavor to use for the build host"
-    default = "m1.small"
+    default = "d2-2"
 }
 
 variable "security_group" {


### PR DESCRIPTION
Fixing Issue #16 

- Updated the default flavor variables and image names
- Gave sample names where it was missing
- Fixed the ansible opensearch role's version to 1.0.1 (1.0.2 was non-existent)
